### PR TITLE
KJHH-1543: Update to spring boot 2.1.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.4.RELEASE</version>
+        <version>2.1.1.RELEASE</version>
     </parent>
 
     <dependencies>

--- a/src/main/java/fi/oph/henkilotietomuutospalvelu/config/scheduling/SchedulingConfiguration.java
+++ b/src/main/java/fi/oph/henkilotietomuutospalvelu/config/scheduling/SchedulingConfiguration.java
@@ -18,9 +18,4 @@ import java.util.concurrent.Executors;
 @ConditionalOnProperty(name = "scheduling.enabled", havingValue = "true")
 public class SchedulingConfiguration {
 
-    @Bean(destroyMethod = "shutdown")
-    public Executor taskScheduler() {
-        // Set to 2 so single long task won't block everything
-        return Executors.newScheduledThreadPool(1);
-    }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   profiles.active: default
   autoconfigure:
     exclude: org.spring


### PR DESCRIPTION
- Poistaa taskScheduler beanin tuplakonfiguraation. Oikeastaan tämä on bugi spring-bootissa https://github.com/spring-projects/spring-boot/issues/15038